### PR TITLE
Initial naive implementation of timeseries parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,12 +94,31 @@ class ATP {
                         }   
                         payload[res.ColumnInfo[i].Name] = val;
                     }
+                } else if(row.Data[i]['TimeSeriesValue']){ 
+                    let timeseriesdata = [];
+                    for(let z=0; z<row.Data[i]['TimeSeriesValue'].length; z++){
+                         let rowresult = {};
+                         rowresult.time = row.Data[i]['TimeSeriesValue'][z].Time;
+                         if(this.isBoolean(row.Data[i]['TimeSeriesValue'][z].Value.ScalarValue)){               // detect if Number or boolean or varchar, timeseries can only be bigint, boolean, double, or varchar
+                             rowresult.value = (row.Data[i]['TimeSeriesValue'][z].Value.ScalarValue == 'true') ? true : false;
+                         }  else if(Number(row.Data[i]['TimeSeriesValue'][z].Value.ScalarValue)!=NaN){          // Try to parse it as a number. If this fails, its a varchar
+                             rowresult.value = Number(""+row.Data[i]['TimeSeriesValue'][z].Value.ScalarValue);
+                         } else {
+                            rowresult.value = row.Data[i]['TimeSeriesValue'][z].Value.ScalarValue;              // if we can't parse it as a bool or a number, its a varchar.
+                          }
+                         timeseriesdata.push(rowresult);
+                     }
+                    payload[res.ColumnInfo[i].Name] = timeseriesdata;                                           // Not sure how create_time_series handles query boundaries. This will fail on data.push if timeseries query can go over query token boundary.
                 }
             }
             data.push(payload)
         })
         return data;
     }
+
+    isBoolean(val) {
+        return val === false || val === true;
+     }
 }
 
 module.exports = new ATP;


### PR DESCRIPTION
A timeseries result can be bigint, double, boolean, or varchar. This commit just attempts to parse a boolean and a number and falls back to varchar as the default. 

Its not clear how timeseries views distribute across query tokens so this implementation will behave in unexpected ways if the query result is not the full timeseries view.  In my testing this has not been a problem returning views if ~1k time/value objects.